### PR TITLE
chore: define a porta padrão para a porta 4000

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 require('dotenv').config();
 
-export const API_PORT = process.env.PORT || '3000'
+export const API_PORT = process.env.PORT || '4000'
 export const API_HOST = process.env.HOSTNAME || 'localhost'
 
 export const ACCESS_EXPIRES = process.env.ACCESS_EXPIRES || '1d'


### PR DESCRIPTION
* altera porta default para 4000 para evitar conflitos na hora de executar simultaneamente o front e back no mesmo host